### PR TITLE
Add maze validation tests and rename awk file for consistency

### DIFF
--- a/test-maze-generator.bats
+++ b/test-maze-generator.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+
+function validate_maze {
+  local -ir rows="$1"
+  local -ir cols="$2"
+  result="$(gawk --file maze-gen-two.awk -v Rows=$rows -v Cols=$cols | gawk -f test-maze.awk -v Rows=$rows -v Cols=$cols)"
+  [ "$result" = "The maze is perfect." ]
+}
+
+@test "the smallest possible maze is perfect" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  validate_maze 2 2
+}
+
+@test "the small square maze is perfect" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  validate_maze 5 5
+}
+
+@test "the small rectangular maze is perfect" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  validate_maze 5 10
+}

--- a/test-maze.awk
+++ b/test-maze.awk
@@ -49,7 +49,7 @@ ENDFILE {
     check_symbols()
     fill_spaces(2, 2)
     check_vertices()
-    print "The maze is valid."
+    print "The maze is perfect."
 }
 
 function check_symbols(   row,col,cell) {


### PR DESCRIPTION
Added a new file for Bats tests to validate the generated mazes. These tests will ensure that all mazes (small, square and rectangular) meet our definition of "perfect". The awk script has also been updated to print "The maze is perfect" when validation passes, for better clarity. To maintain uniformity and to follow naming conventions in the project, maze-test.awk has been renamed to test-maze.awk.