### PR TITLE
Refactor maze validation test and awk file for better readability

### DIFF
--- a/maze-generator.awk
+++ b/maze-generator.awk
@@ -1,0 +1,77 @@
+#!/usr/bin/env gawk -f
+#
+# Copyright (c) 2023 Jegors Čemisovs
+# License: MIT License
+# Repository: https://github.com/rabestro/awk-maze-generator
+#
+# These variables are initialized on the command line (using '-v'):
+# - Rows
+# - Cols
+# - Seed (optional)
+
+BEGIN {
+    OFS = ""
+    Rows = Rows ? Rows : 8
+    Cols = Cols ? Cols : 16
+    Seed ? srand(Seed) : srand()
+
+    Width = 2 * Cols + 1
+    Height = 2 * Rows + 1
+
+    create_grid()
+    generate_maze(1, 1)
+    arrange_doors()
+    print_maze()
+}
+
+function create_grid(    row, col) {
+    for (row = 0; row < Height; row++)
+        for (col = 0; col < Width; col++)
+            Grid[row, col] = 1
+}
+function print_maze(   row, col) {
+    for (row = 0; row < Height; row++) {
+        for (col = 0; col < Width; col++)
+            $(col + 1) = symbol(row, col)
+        print
+    }
+}
+
+# Recursive backtracking algorithm
+function generate_maze(row, col,   directions,randDir,dx,dy,newRow,newCol) {
+    Grid[row, col] = 0
+
+    directions = "NESW"
+    while (length(directions) > 0) {
+        randDir = substr(directions, int(rand() * length(directions)) + 1, 1)
+        sub(randDir, "", directions)
+
+        dx = dy = 0
+        if (randDir == "N") dy = -2
+        if (randDir == "E") dx = 2
+        if (randDir == "S") dy = 2
+        if (randDir == "W") dx = -2
+        newRow = row + dy
+        newCol = col + dx
+
+        if (newRow > 0 && newRow < Height && newCol > 0 && newCol < Width && Grid[newRow, newCol]) {
+            Grid[row + dy / 2, col + dx / 2] = 0
+            generate_maze(newRow, newCol)
+        }
+    }
+}
+function arrange_doors() {
+    MazeEntrance = 1 + 2 * int(rand() * Rows)
+    MazeExit = 1 + 2 * int(rand() * Rows)
+}
+function symbol(row, col,   n,e,s,w) {
+    if (!Grid[row, col]) return " "
+    if (is_door(row, col)) return "⇨"
+    n = row ? Grid[row - 1, col] : 0
+    e = col < Width - 1 ? Grid[row, col + 1] : 0
+    s = row < Height - 1 ? Grid[row + 1, col] : 0
+    w = col ? Grid[row, col - 1] : 0
+    return substr(" │─└││┌├─┘─┴┐┤┬┼", 1 + n + 2 * e + 4 * s + 8 * w, 1)
+}
+
+function is_door(row, col) {return row == MazeEntrance && col == 0 || row == MazeExit && col == Width - 1}

--- a/test-maze-generator.bats
+++ b/test-maze-generator.bats
@@ -1,18 +1,13 @@
 #!/usr/bin/env bats
 
 function validate_maze {
-  local -ir rows="$1"
-  local -ir cols="$2"
-  result="$(gawk --file maze-gen-two.awk -v Rows=$rows -v Cols=$cols | gawk -f test-maze.awk -v Rows=$rows -v Cols=$cols)"
+  result="$(\
+    gawk --file maze-generator.awk --assign Rows=$1 --assign Cols=$2 --assign Seed=$3 \
+    | gawk --file test-maze.awk --assign Rows=$1 --assign Cols=$2 --assign Seed=$3 )"
   [ "$result" = "The maze is perfect." ]
 }
 
-@test "the smallest possible maze is perfect" {
-  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
-  validate_maze 2 2
-}
-
-@test "the small square maze is perfect" {
+@test "the smallest square maze is perfect" {
   #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   validate_maze 5 5
 }
@@ -20,4 +15,50 @@ function validate_maze {
 @test "the small rectangular maze is perfect" {
   #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   validate_maze 5 10
+}
+
+@test "the square maze is perfect" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  validate_maze 10 10
+}
+
+@test "the large rectangular maze is perfect" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  validate_maze 10 20
+}
+
+@test "the rectangular maze with aspect 2:1 is perfect" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  validate_maze 20 10
+}
+
+@test "the huge rectangular maze is perfect" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  validate_maze 20 100
+}
+
+@test "the huge square maze is perfect" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  validate_maze 100 100
+}
+
+@test "if the seed parameter is specified, the perfect maze generated" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  validate_maze 50 50 2342342
+}
+
+@test "if the seed parameter is omitted, random mazes should be generated" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  maze_one=$(gawk --file maze-generator.awk --assign Rows=8 --assign Cols=16)
+  sleep 1
+  maze_two=$(gawk --file maze-generator.awk --assign Rows=8 --assign Cols=16)
+  [[ $maze_one != "$maze_two" ]]
+}
+
+@test "if the seed parameter is specified, the same maze should be generated" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  maze_one=$(gawk --file maze-generator.awk --assign Rows=8 --assign Cols=16 --assign Seed=123)
+  sleep 1
+  maze_two=$(gawk --file maze-generator.awk --assign Rows=8 --assign Cols=16 --assign Seed=123)
+  [[ $maze_one == "$maze_two" ]]
 }


### PR DESCRIPTION
Refactored the validate_maze function in test-maze-generator.bats to reduce the redundancy and improve readability. Also, enhanced the maze tests to ensure different size and aspect ratios of the maze are verified as "perfect". The maze-generator.awk was renamed from maze-gen-two.awk for consistency with the naming convention in the project with more descriptive awk scripts. Now we can check maze generation with or without a specified seed value, and expect the generation of random mazes when the seed parameter is omitted.